### PR TITLE
Fix drupal config logic

### DIFF
--- a/scripts/drupal/init.sh
+++ b/scripts/drupal/init.sh
@@ -185,7 +185,7 @@ fi
 
 # load the config here
 if [[ "$codebase" == "islandora" ]]; then
-  if [[ ! "$(ls -A codebase/config/sync)"  && ! -f codebase/config/sync/core.extension.yml ]]; then
+  if [[ ! -d codebase/config/sync  || ! -f codebase/config/sync/core.extension.yml ]]; then
     tar -xzf config/drupal/islandora-starter-config.tar.gz codebase/config/sync
   fi
 fi


### PR DESCRIPTION
Previously, if the codabase/config/sync directory didn't exist, `ls` would fail with an error.  This changes the test condition logic to un-tar config files if the directory doesn't exist, or doesn't have the expected  `core.extension.yml` file