### PR TITLE
Fix paths on Windows + git bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ solr_init:
 	./scripts/solr/create-core.sh
 
 up:
-	docker-compose -p $(docker_compose_project) up --remove-orphans --detach
+	MSYS_NO_PATHCONV=1 docker-compose -p $(docker_compose_project) up --remove-orphans --detach
 
 build:
-	docker-compose -p $(docker_compose_project) up \
+	MSYS_NO_PATHCONV=1 docker-compose -p $(docker_compose_project) up \
 		--build \
 		--detach \
 		--remove-orphans

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently there are blank `.keep` files in most of the `config/service` director
 
 * Desktop / laptop / VM
 * Docker-CE 19.x+
+  * If using Docker Desktop for Windows, any stable release *after* 2.2.0.4, or use a 2.2.0.4 with a [patch](https://download-stage.docker.com/win/stable/43542/Docker%20Desktop%20Installer.exe) due to a [bug](https://github.com/docker/for-win/issues/6016)
 * Docker-compose version 1.25.x+
 * Git 2.0+
 

--- a/scripts/drupal/init.sh
+++ b/scripts/drupal/init.sh
@@ -151,7 +151,7 @@ if [[ ! $composer ]]; then
   if $is_darwin; then
     composer="docker container run -it --rm --user $UID:$GUID -v $HOME/.composer:/tmp -v $PWD:/app composer:1.9.3"
   else
-    composer="docker container run -t --rm --user $UID:$GUID -v $HOME/.composer:/tmp -v $PWD:/app composer:1.9.3"
+    composer="env MSYS_NO_PATHCONV=1 docker container run -t --rm --user $UID:$GUID -v $HOME/.composer:/tmp -v $PWD:/app composer:1.9.3"
   fi
 fi
 

--- a/scripts/solr/create-core.sh
+++ b/scripts/solr/create-core.sh
@@ -1,1 +1,3 @@
-docker-compose -p islandora exec solr /opt/solr/bin/solr create -c islandora
+#!/bin/bash
+
+env MSYS_NO_PATHCONV=1 docker-compose -p islandora exec -T solr /opt/solr/bin/solr create -c islandora


### PR DESCRIPTION
When using Docker in Windows with MSYS-based bash and tooling (e.g. bash
and unix tools installed with git for Windows), certain paths are
mangled unless MSYS_NO_PATHCONV=1 is enabled.

I just included the env var always when needed, rather than test for the certain flavor of tooling that invokes this issue on Windows.  It should be benign on other OSes and other Windows environments that don't use MSYS-based tooling.